### PR TITLE
[YT-21] Video 페이지 / 연관 동영상 리스트 반응형 로직 수정

### DIFF
--- a/src/views/shared/components/Layout/Layout.styled.js
+++ b/src/views/shared/components/Layout/Layout.styled.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useMediaQuery } from 'react-responsive';
 
 export const ContentContainer = styled.div`
   max-width: 1700px;
@@ -9,3 +10,24 @@ export const SectionContainer = styled.div`
   margin: 0 auto;
   max-width: 1500px;
 `;
+
+export const Desktop = ({ children }) => {
+  const isDesktop = useMediaQuery({ minWidth: 1700 });
+  return isDesktop ? children : null;
+};
+export const LaptopOrDesktop = ({ children }) => {
+  const isLaptopOrDesktop = useMediaQuery({ minWidth: 1200 });
+  return isLaptopOrDesktop ? children : null;
+};
+export const Laptop = ({ children }) => {
+  const isLaptop = useMediaQuery({ minWidth: 1200, maxWidth: 1699 });
+  return isLaptop ? children : null;
+};
+export const Tablet = ({ children }) => {
+  const isTablet = useMediaQuery({ minWidth: 950, maxWidth: 1199 });
+  return isTablet ? children : null;
+};
+export const Mobile = ({ children }) => {
+  const isMobile = useMediaQuery({ maxWidth: 949 });
+  return isMobile ? children : null;
+};

--- a/src/views/video/containers/RelatedVideosContainer.js
+++ b/src/views/video/containers/RelatedVideosContainer.js
@@ -3,13 +3,14 @@ import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import qs from 'qs';
+import cn from 'classnames';
 
 import { ACCESS_KEY } from '../../../const/config';
 import { getNextRelatedVideos, getRelatedVideos } from '../../../redux/search/slice';
 import RelatedVideoItemContainer from './RelatedVideoItemContainer';
 import InfiniteScroll from '../../shared/components/InfiniteScroll';
 
-const RelatedVideosContainer = () => {
+const RelatedVideosContainer = ({ isLaptopOrDesktop }) => {
   const { search } = useLocation();
   const { v } = qs.parse(search, { ignoreQueryPrefix: true });
   const dispatch = useDispatch();
@@ -42,20 +43,41 @@ const RelatedVideosContainer = () => {
 
   useEffect(() => {
     getNewRelatedVideoList();
-  }, [v]);
+  }, [v, isLaptopOrDesktop]);
 
   if (!items) return null;
   return (
-    <Container>
+    <Container className={cn({ isLaptopOrDesktop })}>
       <Grid>
-        <InfiniteScroll next={next}>
-          {
-            items.map((item, index) => {
-              if (!item.snippet) return null;
-              return <RelatedVideoItemContainer item={item} key={index} />;
-            })
-          }
-        </InfiniteScroll>
+        {
+          isLaptopOrDesktop
+            && (
+              <Row>
+                <InfiniteScroll next={next}>
+                  {
+                    items.map((item, index) => {
+                      if (!item.snippet) return null;
+                      return <RelatedVideoItemContainer item={item} key={index} />;
+                    })
+                  }
+                </InfiniteScroll>
+              </Row>
+            )
+        }
+        {
+          !isLaptopOrDesktop
+            && (
+              <Row>
+                {
+                  items.map((item, index) => {
+                    if (!item.snippet) return null;
+                    return <RelatedVideoItemContainer item={item} key={index} />;
+                  })
+                }
+                <MoreButton onClick={next}>더보기</MoreButton>
+              </Row>
+            )
+        }
       </Grid>
     </Container>
   );
@@ -63,10 +85,27 @@ const RelatedVideosContainer = () => {
 
 const Container = styled.div`
   flex-shrink: 0;
-  width: 400px;
+  width: 100%;
+  &.isLaptopOrDesktop{
+    width: 400px;
+  }
 `;
 const Grid = styled.div`
   display: flex;
   flex-direction: column;
+`;
+const Row = styled.div`
+  
+`;
+const MoreButton = styled.div`
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #32a6ff;
+  border-radius: 3px;
+  text-align: center;
+  color: #32a6ff;
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: 10px;
 `;
 export default RelatedVideosContainer;

--- a/src/views/video/containers/VideoContainer.js
+++ b/src/views/video/containers/VideoContainer.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
 import qs from 'qs';
 import { useDispatch, useSelector } from 'react-redux';
+import { useMediaQuery } from 'react-responsive';
 
 import { getVideoById } from '../../../redux/video/slice';
 import { ACCESS_KEY } from '../../../const/config';
@@ -17,6 +18,7 @@ const VideoContainer = () => {
   const { v } = qs.parse(search, { ignoreQueryPrefix: true });
   const dispatch = useDispatch();
   const { data } = useSelector((state) => state.video);
+  const isLaptopOrDesktop = useMediaQuery({ minWidth: 1200 });
 
   useEffect(() => {
     dispatch(getVideoById({
@@ -36,10 +38,17 @@ const VideoContainer = () => {
         <RelatedDetailSection>
           <VideoDetailInfo data={data?.items?.[0]} />
           <VideoChannelInfo />
+          {
+            !isLaptopOrDesktop
+              && <RelatedVideosContainer isLaptopOrDesktop={false} />
+          }
           <CommentsContainer id={v} commentCount={data?.items?.[0].statistics.commentCount} />
         </RelatedDetailSection>
       </SectionContainer>
-      <RelatedVideosContainer />
+      {
+        isLaptopOrDesktop
+          && <RelatedVideosContainer isLaptopOrDesktop />
+      }
     </Container>
 
   );


### PR DESCRIPTION
태블릿 사이즈부터 연관영상리스트가 채널정보컴포넌트랑 댓글컴포넌트 사이로 이동해야함intersection observer를 사용하지 않고 버튼을 만들어서 클릭시 데이터 추가로 받아오도록 수정